### PR TITLE
Changes to handle GTFS static data for MTA buses

### DIFF
--- a/static.go
+++ b/static.go
@@ -418,8 +418,11 @@ func ParseStatic(content []byte, opts ParseStaticOptions) (*Static, error) {
 		{
 			File: "transfers.txt",
 			Action: func(file *csv.File) {
-				result.Transfers = parseTransfers(file, result.Stops)
+				if file != nil {
+					result.Transfers = parseTransfers(file, result.Stops)
+				}
 			},
+			Optional: true,
 		},
 		{
 			File: "calendar.txt",
@@ -639,7 +642,7 @@ func parseFloat64(raw *string) *float64 {
 	if raw == nil {
 		return nil
 	}
-	f, err := strconv.ParseFloat(*raw, 64)
+	f, err := strconv.ParseFloat(strings.TrimSpace(*raw), 64)
 	if err != nil {
 		return nil
 	}

--- a/static_test.go
+++ b/static_test.go
@@ -363,6 +363,33 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "stop with spaces in lat/lon",
+			content: newZipBuilder().add(
+				"stops.txt",
+				"stop_id,stop_code,stop_name,stop_desc,zone_id,stop_lon,stop_lat,"+
+					"stop_url,location_type,stop_timezone,wheelchair_boarding,platform_code\n"+
+					"a,b,c,d,e, 1.5 , 2.5 ,f,1,g,1,h",
+			).build(),
+			expected: &Static{
+				Stops: []Stop{
+					{
+						Id:                 "a",
+						Code:               ptr("b"),
+						Name:               ptr("c"),
+						Description:        ptr("d"),
+						ZoneId:             ptr("e"),
+						Longitude:          floatPtr(1.5),
+						Latitude:           floatPtr(2.5),
+						Url:                ptr("f"),
+						Type:               Station,
+						Timezone:           ptr("g"),
+						WheelchairBoarding: Possible,
+						PlatformCode:       ptr("h"),
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			actual, err := ParseStatic(tc.content, tc.opts)


### PR DESCRIPTION
This PR contains 2 changes to handle the GTFS data provided for MTA buses: http://web.mta.info/developers/developer-data-terms.html#data

1. Make the `transfers.txt` file optional, as this is not included.
2. Handle spaces around `stop_lat`/`stop_lon` in `stops.txt`.

Though these changes are in response to idiosyncrasies in the MTA bus static data, I believe they are generally useful for parsing in general, and thus are not so specific as to warrant an extension. 