### PR TITLE
Handle byte order marks in CSV data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,10 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
+golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/static_test.go
+++ b/static_test.go
@@ -406,6 +406,33 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "data with BOM",
+			content: newZipBuilder().add(
+				"stops.txt",
+				"\xEF\xBB\xBFstop_id,stop_code,stop_name,stop_desc,zone_id,stop_lon,stop_lat,"+
+					"stop_url,location_type,stop_timezone,wheelchair_boarding,platform_code\n"+
+					"a,b,c,d,e,1.5,2.5,f,1,g,1,h",
+			).build(),
+			expected: &Static{
+				Stops: []Stop{
+					{
+						Id:                 "a",
+						Code:               ptr("b"),
+						Name:               ptr("c"),
+						Description:        ptr("d"),
+						ZoneId:             ptr("e"),
+						Longitude:          floatPtr(1.5),
+						Latitude:           floatPtr(2.5),
+						Url:                ptr("f"),
+						Type:               Station,
+						Timezone:           ptr("g"),
+						WheelchairBoarding: Possible,
+						PlatformCode:       ptr("h"),
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			actual, err := ParseStatic(tc.content, tc.opts)


### PR DESCRIPTION
Handle cases where CSV files have a byte order mark, which appears to be the case with the [NYC ferry GTFS feed](https://www.ferry.nyc/developer-tools/). There is a discussion of handling this case in Go [here](https://stackoverflow.com/questions/21371673/reading-files-with-a-bom-in-go).