### PR TITLE
Fix Vehicle attribute output in CLI

### DIFF
--- a/cmd/gtfs.go
+++ b/cmd/gtfs.go
@@ -126,7 +126,7 @@ func formatTrip(trip gtfs.Trip, indent int, printStopTimes bool) string {
 		newLine,
 	)
 	if trip.Vehicle != nil {
-		fmt.Fprintf(&b, "Vehicle: ID %s%s", vc.Sprint(trip.Vehicle.GetID().ID), newLine)
+		fmt.Fprintf(&b, "Vehicle: ID %s%s", vc.Sprint(unPtr(trip.Vehicle.GetID().ID)), newLine)
 	} else {
 		fmt.Fprintf(&b, "Vehicle: <none>%s", newLine)
 	}
@@ -185,9 +185,9 @@ func formatVehicle(vehicle gtfs.Vehicle, indent int) string {
 	newLine := fmt.Sprintf("\n%*s", indent, "")
 	fmt.Fprintf(&b,
 		"VehicleID %s  Label %s  LicencePlate %s%s",
-		tc.Sprint(vehicle.ID.ID),
-		tc.Sprint(vehicle.ID.Label),
-		tc.Sprint(vehicle.ID.LicencePlate),
+		tc.Sprint(unPtr(vehicle.GetID().ID)),
+		tc.Sprint(unPtr(vehicle.GetID().Label)),
+		tc.Sprint(unPtr(vehicle.GetID().LicencePlate)),
 		newLine,
 	)
 	if vehicle.Trip != nil {


### PR DESCRIPTION
Fix a few formatting bugs in the CLI output where raw pointers are being used instead of their de-referenced values.