### PR TITLE
Incorporate `DirectionID` in trip hash

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -39,6 +39,7 @@ func (h *hasher) flush() {
 func (h *hasher) trip(t *Trip) {
 	h.string(t.ID.ID)
 	h.string(t.ID.RouteID)
+	h.number(t.ID.DirectionID)
 	h.number(t.ID.HasStartDate)
 	h.number(t.ID.StartDate.Unix())
 	h.number(t.ID.HasStartTime)

--- a/hash_test.go
+++ b/hash_test.go
@@ -36,6 +36,12 @@ func TestHashTrip(t *testing.T) {
 			},
 		},
 		{
+			"id.direction_id",
+			func(t *Trip) any {
+				return &t.ID.DirectionID
+			},
+		},
+		{
 			"id.has_start_date",
 			func(t *Trip) any {
 				return &t.ID.HasStartDate
@@ -407,6 +413,8 @@ func allModifiers(a any) []modifier {
 		return []modifier{noOpModifier, otherValueModifier}
 	case **OccupancyStatus:
 		return []modifier{noOpModifier, otherValueModifier, nilModifier}
+	case *DirectionID:
+		return []modifier{noOpModifier, otherValueModifier}
 	default:
 		panic(fmt.Sprintf("invalid type %T", a))
 	}
@@ -512,6 +520,8 @@ func otherValueModifierFn(a any) {
 		*t = gtfsrt.VehiclePosition_STOP_AND_GO
 	case **OccupancyStatus:
 		*t = ptr(gtfsrt.VehiclePosition_CRUSHED_STANDING_ROOM_ONLY)
+	case *DirectionID:
+		*t = DirectionID_True
 	default:
 		panic(fmt.Sprintf("invalid type %T", a))
 	}


### PR DESCRIPTION
Small change to use `DirectionID` in trip hash. I noticed this when I was unable to update the direction of an existing trip in a Transiter unit test (due to the GTFS hash check). I don't think this breaks any assumptions about trip equality, but wanted to double-check before merging.