### PR TITLE
Return `Trip` entities from `Alert`s

### DIFF
--- a/realtime_test.go
+++ b/realtime_test.go
@@ -247,6 +247,14 @@ func TestRealtime(t *testing.T) {
 						},
 					},
 				},
+				Trips: []gtfs.Trip{
+					{
+						ID: gtfs.TripID{
+							ID: "TripID",
+						},
+						IsEntityInMessage: false,
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
To be consistent with how `Trip` and `Vehicle` behave, this change also adds partial `Trip` entities that are informed entities of a parsed `Alert`.