### PR TITLE
Support stop_times interpolation: equal intervals or shape_dist_traveled

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -1,0 +1,115 @@
+package gtfs
+
+import (
+	"time"
+)
+
+// InterpolateStopTimes Helper: interpolate missing arrival or departure times evenly
+func interpolateStopTimes(times []ScheduledStopTime) []ScheduledStopTime {
+	// Work on a copy so the original slice is not modified outside
+	result := make([]ScheduledStopTime, len(times))
+	copy(result, times)
+	n := len(result)
+	if n == 0 {
+		return result
+	}
+
+	// Interpolate Arrival and Departure separately
+	for tType := 0; tType < 2; tType++ {
+		// tType: 0 = ArrivalTime, 1 = DepartureTime
+		i := 0
+		for i < n {
+			// Find the next known time
+			if getTime(&result[i], tType) == 0 {
+				// Start of missing segment
+				startIdx := i - 1
+				startTime := time.Duration(0)
+				if startIdx >= 0 {
+					startTime = getTime(&result[startIdx], tType)
+				}
+				// Find end of missing segment
+				endIdx := i
+				for endIdx < n && getTime(&result[endIdx], tType) == 0 {
+					endIdx++
+				}
+				endTime := time.Duration(0)
+				if endIdx < n {
+					endTime = getTime(&result[endIdx], tType)
+				}
+				intervals := endIdx - startIdx
+				if startIdx >= 0 && endIdx < n && endTime > startTime && intervals > 0 {
+					delta := (endTime - startTime) / time.Duration(intervals)
+					for j := 1; j < intervals; j++ {
+						setTime(&result[startIdx+j], tType, startTime+time.Duration(j)*delta)
+					}
+				}
+				i = endIdx
+			} else {
+				i++
+			}
+		}
+	}
+	return result
+}
+
+func interpolateStopTimesByShapeDist(times []ScheduledStopTime) []ScheduledStopTime {
+	result := make([]ScheduledStopTime, len(times))
+	copy(result, times)
+	n := len(result)
+	if n == 0 {
+		return result
+	}
+
+	for tType := 0; tType < 2; tType++ {
+		i := 0
+		for i < n {
+			if getTime(&result[i], tType) == 0 {
+				startIdx := i - 1
+				var startTime time.Duration
+				var startDist float64
+				if startIdx >= 0 && result[startIdx].ShapeDistanceTraveled != nil {
+					startTime = getTime(&result[startIdx], tType)
+					startDist = *result[startIdx].ShapeDistanceTraveled
+				}
+				endIdx := i
+				for endIdx < n && getTime(&result[endIdx], tType) == 0 {
+					endIdx++
+				}
+				var endTime time.Duration
+				var endDist float64
+				if endIdx < n && result[endIdx].ShapeDistanceTraveled != nil {
+					endTime = getTime(&result[endIdx], tType)
+					endDist = *result[endIdx].ShapeDistanceTraveled
+				}
+				intervals := endIdx - startIdx
+				if startIdx >= 0 && endIdx < n && endDist > startDist && endTime > startTime && intervals > 0 {
+					for j := 1; j < intervals; j++ {
+						dist := *result[startIdx+j].ShapeDistanceTraveled
+						w := (dist - startDist) / (endDist - startDist)
+						interpolated := startTime + time.Duration(float64(endTime-startTime)*w)
+						setTime(&result[startIdx+j], tType, interpolated)
+					}
+				}
+				i = endIdx
+			} else {
+				i++
+			}
+		}
+	}
+	return result
+}
+
+// Helpers to get/set arrival/departure by index
+func getTime(stop *ScheduledStopTime, tType int) time.Duration {
+	if tType == 0 {
+		return stop.ArrivalTime
+	}
+	return stop.DepartureTime
+}
+func setTime(stop *ScheduledStopTime, tType int, t time.Duration) {
+	if tType == 0 {
+		stop.ArrivalTime = t
+	} else {
+		stop.DepartureTime = t
+	}
+}

--- a/interpolate.go
+++ b/interpolate.go
@@ -11,7 +11,7 @@ func interpolateStopTimes(times []ScheduledStopTime) []ScheduledStopTime {
 	copy(result, times)
 	n := len(result)
 	if n == 0 {
-		return result
+		return nil
 	}
 
 	// Interpolate Arrival and Departure separately
@@ -57,7 +57,7 @@ func interpolateStopTimesByShapeDist(times []ScheduledStopTime) []ScheduledStopT
 	copy(result, times)
 	n := len(result)
 	if n == 0 {
-		return result
+		return nil
 	}
 
 	for tType := 0; tType < 2; tType++ {

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -1,0 +1,150 @@
+package gtfs
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// Simple helper: parse "08:00:00" to time.Duration
+func dur(s string) time.Duration {
+	t, _ := time.Parse("15:04:05", s)
+	return time.Duration(t.Hour())*time.Hour + time.Duration(t.Minute())*time.Minute + time.Duration(t.Second())*time.Second
+}
+func almostEq(a, b time.Duration) bool {
+	return math.Abs(float64(a-b)) < float64(time.Second)
+}
+
+// --- Tests for interpolateStopTimes (equal, no distance) ---
+
+func TestInterpolateStopTimes_Normal(t *testing.T) {
+	st := []ScheduledStopTime{
+		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00")},
+		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0},
+		{StopSequence: 3, ArrivalTime: 0, DepartureTime: 0},
+		{StopSequence: 4, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00")},
+	}
+	wantArr := []time.Duration{dur("08:00:00"), dur("08:10:00"), dur("08:20:00"), dur("08:30:00")}
+	wantDep := []time.Duration{dur("08:05:00"), dur("08:15:00"), dur("08:25:00"), dur("08:35:00")}
+
+	got := interpolateStopTimes(st)
+	for i := range got {
+		if !almostEq(got[i].ArrivalTime, wantArr[i]) {
+			t.Errorf("normal: arrival %d: want %v got %v", i, wantArr[i], got[i].ArrivalTime)
+		}
+		if !almostEq(got[i].DepartureTime, wantDep[i]) {
+			t.Errorf("normal: depart %d: want %v got %v", i, wantDep[i], got[i].DepartureTime)
+		}
+	}
+}
+
+func TestInterpolateStopTimes_MissingFirst(t *testing.T) {
+	st := []ScheduledStopTime{
+		{StopSequence: 1, ArrivalTime: 0, DepartureTime: 0},
+		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0},
+		{StopSequence: 3, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00")},
+	}
+	got := interpolateStopTimes(st)
+	// The first two should remain zero, last should be as input
+	if got[0].ArrivalTime != 0 || got[1].ArrivalTime != 0 {
+		t.Errorf("first missing: arrivals should remain zero, got: %v %v", got[0].ArrivalTime, got[1].ArrivalTime)
+	}
+	if got[0].DepartureTime != 0 || got[1].DepartureTime != 0 {
+		t.Errorf("first missing: departures should remain zero, got: %v %v", got[0].DepartureTime, got[1].DepartureTime)
+	}
+	if !almostEq(got[2].ArrivalTime, dur("08:30:00")) {
+		t.Errorf("first missing: last arrival wrong, got %v", got[2].ArrivalTime)
+	}
+	if !almostEq(got[2].DepartureTime, dur("08:35:00")) {
+		t.Errorf("first missing: last depart wrong, got %v", got[2].DepartureTime)
+	}
+}
+
+func TestInterpolateStopTimes_MissingLast(t *testing.T) {
+	st := []ScheduledStopTime{
+		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00")},
+		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0},
+		{StopSequence: 3, ArrivalTime: 0, DepartureTime: 0},
+	}
+	got := interpolateStopTimes(st)
+	// The first should be as input, the last two should remain zero
+	if !almostEq(got[0].ArrivalTime, dur("08:00:00")) {
+		t.Errorf("last missing: first arrival wrong, got %v", got[0].ArrivalTime)
+	}
+	if !almostEq(got[0].DepartureTime, dur("08:05:00")) {
+		t.Errorf("last missing: first depart wrong, got %v", got[0].DepartureTime)
+	}
+	if got[1].ArrivalTime != 0 || got[2].ArrivalTime != 0 {
+		t.Errorf("last missing: arrivals should remain zero, got: %v %v", got[1].ArrivalTime, got[2].ArrivalTime)
+	}
+	if got[1].DepartureTime != 0 || got[2].DepartureTime != 0 {
+		t.Errorf("last missing: departures should remain zero, got: %v %v", got[1].DepartureTime, got[2].DepartureTime)
+	}
+}
+
+// --- Tests for interpolateStopTimesByShapeDist (distance-weighted) ---
+
+func TestInterpolateStopTimesByShapeDist_Normal(t *testing.T) {
+	st := []ScheduledStopTime{
+		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00"), ShapeDistanceTraveled: ptr(0.0)},
+		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(3.5)},
+		{StopSequence: 3, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(7.0)},
+		{StopSequence: 4, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00"), ShapeDistanceTraveled: ptr(10.5)},
+	}
+	wantArr := []time.Duration{dur("08:00:00"), dur("08:10:00"), dur("08:20:00"), dur("08:30:00")}
+	wantDep := []time.Duration{dur("08:05:00"), dur("08:15:00"), dur("08:25:00"), dur("08:35:00")}
+
+	got := interpolateStopTimesByShapeDist(st)
+	for i := range got {
+		if !almostEq(got[i].ArrivalTime, wantArr[i]) {
+			t.Errorf("shape normal: arrival %d: want %v got %v", i, wantArr[i], got[i].ArrivalTime)
+		}
+		if !almostEq(got[i].DepartureTime, wantDep[i]) {
+			t.Errorf("shape normal: depart %d: want %v got %v", i, wantDep[i], got[i].DepartureTime)
+		}
+	}
+}
+
+func TestInterpolateStopTimesByShapeDist_MissingFirst(t *testing.T) {
+	st := []ScheduledStopTime{
+		{StopSequence: 1, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(0.0)},
+		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(3.5)},
+		{StopSequence: 3, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00"), ShapeDistanceTraveled: ptr(10.5)},
+	}
+	got := interpolateStopTimesByShapeDist(st)
+	// The first two should remain zero, last should be as input
+	if got[0].ArrivalTime != 0 || got[1].ArrivalTime != 0 {
+		t.Errorf("shape first missing: arrivals should remain zero, got: %v %v", got[0].ArrivalTime, got[1].ArrivalTime)
+	}
+	if got[0].DepartureTime != 0 || got[1].DepartureTime != 0 {
+		t.Errorf("shape first missing: departures should remain zero, got: %v %v", got[0].DepartureTime, got[1].DepartureTime)
+	}
+	if !almostEq(got[2].ArrivalTime, dur("08:30:00")) {
+		t.Errorf("shape first missing: last arrival wrong, got %v", got[2].ArrivalTime)
+	}
+	if !almostEq(got[2].DepartureTime, dur("08:35:00")) {
+		t.Errorf("shape first missing: last depart wrong, got %v", got[2].DepartureTime)
+	}
+}
+
+func TestInterpolateStopTimesByShapeDist_MissingLast(t *testing.T) {
+	st := []ScheduledStopTime{
+		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00"), ShapeDistanceTraveled: ptr(0.0)},
+		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(3.5)},
+		{StopSequence: 3, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(10.5)},
+	}
+	got := interpolateStopTimesByShapeDist(st)
+	// The first should be as input, the last two should remain zero
+	if !almostEq(got[0].ArrivalTime, dur("08:00:00")) {
+		t.Errorf("shape last missing: first arrival wrong, got %v", got[0].ArrivalTime)
+	}
+	if !almostEq(got[0].DepartureTime, dur("08:05:00")) {
+		t.Errorf("shape last missing: first depart wrong, got %v", got[0].DepartureTime)
+	}
+	if got[1].ArrivalTime != 0 || got[2].ArrivalTime != 0 {
+		t.Errorf("shape last missing: arrivals should remain zero, got: %v %v", got[1].ArrivalTime, got[2].ArrivalTime)
+	}
+	if got[1].DepartureTime != 0 || got[2].DepartureTime != 0 {
+		t.Errorf("shape last missing: departures should remain zero, got: %v %v", got[1].DepartureTime, got[2].DepartureTime)
+	}
+}

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -19,13 +19,14 @@ func almostEq(a, b time.Duration) bool {
 
 func TestInterpolateStopTimes_Normal(t *testing.T) {
 	st := []ScheduledStopTime{
-		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00")},
+		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00"), ExactTimes: true},
 		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0},
 		{StopSequence: 3, ArrivalTime: 0, DepartureTime: 0},
-		{StopSequence: 4, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00")},
+		{StopSequence: 4, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00"), ExactTimes: true},
 	}
 	wantArr := []time.Duration{dur("08:00:00"), dur("08:10:00"), dur("08:20:00"), dur("08:30:00")}
 	wantDep := []time.Duration{dur("08:05:00"), dur("08:15:00"), dur("08:25:00"), dur("08:35:00")}
+	wantTimePoint := []bool{true, false, false, true}
 
 	got := interpolateStopTimes(st)
 	for i := range got {
@@ -34,6 +35,9 @@ func TestInterpolateStopTimes_Normal(t *testing.T) {
 		}
 		if !almostEq(got[i].DepartureTime, wantDep[i]) {
 			t.Errorf("normal: depart %d: want %v got %v", i, wantDep[i], got[i].DepartureTime)
+		}
+		if got[i].ExactTimes != wantTimePoint[i] {
+			t.Errorf("timepoint %d: want %v got %v", i, wantTimePoint[i], got[i].ExactTimes)
 		}
 	}
 }
@@ -86,13 +90,14 @@ func TestInterpolateStopTimes_MissingLast(t *testing.T) {
 
 func TestInterpolateStopTimesByShapeDist_Normal(t *testing.T) {
 	st := []ScheduledStopTime{
-		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00"), ShapeDistanceTraveled: ptr(0.0)},
+		{StopSequence: 1, ArrivalTime: dur("08:00:00"), DepartureTime: dur("08:05:00"), ShapeDistanceTraveled: ptr(0.0), ExactTimes: true},
 		{StopSequence: 2, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(3.5)},
 		{StopSequence: 3, ArrivalTime: 0, DepartureTime: 0, ShapeDistanceTraveled: ptr(7.0)},
-		{StopSequence: 4, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00"), ShapeDistanceTraveled: ptr(10.5)},
+		{StopSequence: 4, ArrivalTime: dur("08:30:00"), DepartureTime: dur("08:35:00"), ShapeDistanceTraveled: ptr(10.5), ExactTimes: true},
 	}
 	wantArr := []time.Duration{dur("08:00:00"), dur("08:10:00"), dur("08:20:00"), dur("08:30:00")}
 	wantDep := []time.Duration{dur("08:05:00"), dur("08:15:00"), dur("08:25:00"), dur("08:35:00")}
+	wantTimePoint := []bool{true, false, false, true}
 
 	got := interpolateStopTimesByShapeDist(st)
 	for i := range got {
@@ -101,6 +106,9 @@ func TestInterpolateStopTimesByShapeDist_Normal(t *testing.T) {
 		}
 		if !almostEq(got[i].DepartureTime, wantDep[i]) {
 			t.Errorf("shape normal: depart %d: want %v got %v", i, wantDep[i], got[i].DepartureTime)
+		}
+		if got[i].ExactTimes != wantTimePoint[i] {
+			t.Errorf("timepoint %d: want %v got %v", i, wantTimePoint[i], got[i].ExactTimes)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds support for linear interpolation of missing `arrival_time` and `departure_time` values in `stop_times.txt` for each trip.

- If the `shape_dist_traveled` field is **absent**, the interpolation distributes missing times evenly between known times (equal intervals).
- If the `shape_dist_traveled` field is **present**, the interpolation uses the shape distance to assign missing times according to the distance traveled between stops proportionally.

## Motivation

Previously, trips with missing arrival or departure times would either skip those stop times or leave them unset, which could cause issues for downstream consumers expecting complete time data. This feature ensures that all stops in a trip have valid arrival and departure times, improving data quality and making the library more compliant with GTFS best practices.

## Implementation

- After parsing and sorting stop times for each trip, the code now:
  - Finds sequences of stops with missing times, bounded by stops with valid times.
  - Evenly interpolates the missing times between the previous and next known times.
  - Handles both `ArrivalTime` and `DepartureTime` independently.
  - Leaves times as zero if missing at the start or end of the trip with no bounding known value.
- The interpolation is performed in a helper function and integrated into `parseScheduledStopTimes`.
- Includes inline documentation to describe the approach.

## Example

Given stops with times:
| Stop Sequence | Arrival Time | Departure Time |
|---------------|-------------|---------------|
| 1             | 08:00:00    | 08:00:00      |
| 2             |             |               |
| 3             |             |               |
| 4             | 08:30:00    | 08:30:00      |

The missing times for stops 2 and 3 will be interpolated as:
- Stop 2: 08:10:00
- Stop 3: 08:20:00

## Can we do better?

OneBusAway calculates interpolated stop times based on the cumulative distance traveled along the shape (i.e., the route’s polyline). For each stop, OBA projects its location onto the shape and uses that “distance along shape” to perform time interpolation. It calculates the  `shape_dist_traveled` even if it's not found.

I located the core logic for this process here:
https://github.com/OneBusAway/onebusaway-application-modules/blob/main/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/DistanceAlongShapeLibrary.java

## Tests

- Existing tests now pass with the new logic.
- Add tests for the logic of interpolating functions logic

## Refrences 
- https://github.com/google/transit/issues/61
- https://rdrr.io/cran/tidytransit/man/interpolate_stop_times.html