### PR TITLE
feat: headsign for trips

### DIFF
--- a/realtime.go
+++ b/realtime.go
@@ -25,6 +25,7 @@ type Realtime struct {
 
 type Trip struct {
 	ID              TripID
+	Headsign        *string
 	StopTimeUpdates []StopTimeUpdate
 
 	Vehicle *Vehicle


### PR DESCRIPTION
New optional `Headsign` field on `Trip` per GTFS spec.

https://gtfs.org/documentation/schedule/reference/#tripstxt

> **trip_headsign**
> *Optional*
> Text that appears on signage identifying the trip's destination to riders. This field is recommended for all services with headsign text displayed on the vehicle which may be used to distinguish amongst trips in a route.
>
> If the headsign changes during a trip, values for trip_headsign may be overridden by defining values in stop_times.stop_headsign for specific stop_times along the trip.